### PR TITLE
Fix UUIDv4 pattern in 'UUIDv4Format'

### DIFF
--- a/utm.yaml
+++ b/utm.yaml
@@ -125,7 +125,7 @@ components:
       type: string
       format: uuid
       pattern: >-
-        ^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-4[0-9a-fA-F]{3}\-[8-b][0-9a-fA-F]{3}\-[0-9a-fA-F]{12}$
+        ^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-4[0-9a-fA-F]{3}\-[89abAB][0-9a-fA-F]{3}\-[0-9a-fA-F]{12}$
       example: 03e5572a-f733-49af-bc14-8a18bd53ee39
     EntityID:
       description: >-


### PR DESCRIPTION
Previous pattern is wrong: it does not cover upper case for one of the characters.
This PR fixes that.