### PR TITLE
Factor out 'EntityVersion' from existing definitions

### DIFF
--- a/utm.yaml
+++ b/utm.yaml
@@ -148,6 +148,16 @@ components:
       minLength: 16
       maxLength: 128
       example: 9d158f59-80b7-4c11-9c0c-8a2b4d936b2d
+    EntityVersion:
+      title: EntityVersion
+      description: >-
+        Numeric version of this entity which increments upon each change in the
+        entity, regardless of whether any field of the entity changes.  A USS
+        with the details of this entity when it was at a particular version does
+        not need to retrieve the details again until the version changes.
+      type: integer
+      format: int32
+      example: 1
     SubscriptionID:
       description: >-
         Identifier for a subscription communicated through the DSS.  Formatted
@@ -657,16 +667,7 @@ components:
         uss_availability:
           $ref: '#/components/schemas/UssAvailabilityState'
         version:
-          type: integer
-          format: int32
-          example: 1
-          description: >-
-            Numeric version of this operational intent which increments upon
-            each change in the operational intent, regardless of whether any
-            field of the operational intent reference changes.  A USS with the
-            details of this operational intent when it was at a particular
-            version does not need to retrieve the details again until the
-            version changes.
+          $ref: '#/components/schemas/EntityVersion'
         state:
           $ref: '#/components/schemas/OperationalIntentState'
         ovn:
@@ -883,15 +884,7 @@ components:
         uss_availability:
           $ref: '#/components/schemas/UssAvailabilityState'
         version:
-          type: integer
-          format: int32
-          example: 1
-          description: >-
-            Numeric version of this constraint which increments upon each change
-            in the constraint, regardless of whether any field of the constraint
-            reference changes.  A USS with the details of this constraint when
-            it was at a particular version does not need to retrieve the details
-            again until the version changes.
+          $ref: '#/components/schemas/EntityVersion'
         ovn:
           description: >-
             Opaque version number of this constraint.  Populated only when the


### PR DESCRIPTION
An upcoming PR will add another use of the version schema.
This is already defined twice in almost duplicate fashion.
This PR factors out the definition into a new schema 'EntityVersion'.